### PR TITLE
Update framework to work in both Python 2 and 3

### DIFF
--- a/topoflow/__init__.py
+++ b/topoflow/__init__.py
@@ -1,15 +1,15 @@
 
 SILENT = False
 if not(SILENT):
-    print 'Importing TopoFlow 3.5 packages:'
-    print '   topoflow.utils'
-    print '   topoflow.utils.tests'
-    print '   topoflow.components'
-    print '   topoflow.components.tests'
-    print '   topoflow.framework'
-    print '   topoflow.framework.tests'
+    print('Importing TopoFlow 3.5 packages:')
+    print('   topoflow.utils')
+    print('   topoflow.utils.tests')
+    print('   topoflow.components')
+    print('   topoflow.components.tests')
+    print('   topoflow.framework')
+    print('   topoflow.framework.tests')
     # print '   topoflow.gui (unfinished)'
-    print ' '
+    print(' ')
 
 import topoflow.utils
 import topoflow.utils.tests

--- a/topoflow/framework/emeli.py
+++ b/topoflow/framework/emeli.py
@@ -192,14 +192,14 @@ examples_dir  = examples_dir  + os.sep
 
 SILENT = False
 if not(SILENT):
-	# print ' '
-	print('Paths for this package:')
-	print('framework_dir = %s' % framework_dir)
-	print('parent_dir    = %s' % parent_dir)
-	print('examples_dir  = %s' % examples_dir)
-	print('__file__      = %s' % __file__)
-	print('__name__      = %s' % __name__)
-	print(' ')
+    # print ' '
+    print('Paths for this package:')
+    print('framework_dir = %s' % framework_dir)
+    print('parent_dir    = %s' % parent_dir)
+    print('examples_dir  = %s' % examples_dir)
+    print('__file__      = %s' % __file__)
+    print('__name__      = %s' % __name__)
+    print(' ')
 
 #--------------------------------------
 # Save the full paths in a dictionary
@@ -267,31 +267,31 @@ class framework():
     secs_per_year  = 365 * secs_per_day
     secs_per_month = secs_per_year / 12    #########
 
-# 	##################################################################
-# 	# NOTE:  "get_package_paths" will not work as intended on Python
-# 	# versions less than 3.4 if os.chddir() is called between two
-# 	# calls to get_package_paths().  This is a known Python issue
-# 	# that has been discussed frequently online.  (9/17/14)
-# 	##################################################################
+#     ##################################################################
+#     # NOTE:  "get_package_paths" will not work as intended on Python
+#     # versions less than 3.4 if os.chddir() is called between two
+#     # calls to get_package_paths().  This is a known Python issue
+#     # that has been discussed frequently online.  (9/17/14)
+#     ##################################################################
 # 
-# 	#------------------------------------------------------
-# 	# Get path to the current file (emeli.py).  (7/29/13)
-# 	# At top need: "#! /usr/bin/env python" ??
-# 	# See: https://docs.python.org/2/library/os.path.html
-# 	#------------------------------------------------------
+#     #------------------------------------------------------
+#     # Get path to the current file (emeli.py).  (7/29/13)
+#     # At top need: "#! /usr/bin/env python" ??
+#     # See: https://docs.python.org/2/library/os.path.html
+#     #------------------------------------------------------
 #     framework_dir = os.path.dirname( __file__ )
 #     parent_dir    = os.path.join( framework_dir, '..' )
 #     # parent_dir    = os.path.join( framework_dir, os.path.pardir )
 #     examples_dir  = os.path.join( parent_dir, 'examples' )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 #     framework_dir = os.path.abspath( framework_dir )
 #     parent_dir    = os.path.abspath( parent_dir )
 #     examples_dir  = os.path.abspath( examples_dir )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 # #     framework_dir = os.path.realpath( framework_dir )
 # #     parent_dir    = os.path.realpath( parent_dir )
 # #     examples_dir  = os.path.realpath( examples_dir )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 #     framework_dir = framework_dir + os.sep
 #     parent_dir    = parent_dir    + os.sep
 #     examples_dir  = examples_dir  + os.sep
@@ -306,15 +306,15 @@ class framework():
 #         print '__file__      =', __file__
 #         print '__name__      =', __name__
 #         print ' '
-# 	
-# 	#--------------------------------------
-# 	# Save the full paths in a dictionary
-# 	#--------------------------------------
+#     
+#     #--------------------------------------
+#     # Save the full paths in a dictionary
+#     #--------------------------------------
 #     paths = dict()
 #     paths['framework']        = framework_dir
 #     paths['examples']         = examples_dir
 #     paths['framework_parent'] = parent_dir
-		
+        
     #-------------------------------------------------------------------
     def read_repository( self, SILENT=True ):
 
@@ -786,13 +786,13 @@ class framework():
 #         p_units = p_bmi.get_var_units( long_var_name )
 #         u_units = u_bmi.get_var_units( long_var_name )     
 #         if (u_units != p_units):
-# # 			print '#### long_var_name = ' + long_var_name
-# # 			print '#### provider_name = ' + provider_name
-# # 			print '#### user_name     = ' + user_name
-# # 			print '#### p_units       = ' + p_units
-# # 			print '#### u_units       = ' + u_units
-# 			#---------------------------------------------- 
-# 			values = Units.conform( values, Units(p_units), Units(u_units) )
+# #             print '#### long_var_name = ' + long_var_name
+# #             print '#### provider_name = ' + provider_name
+# #             print '#### user_name     = ' + user_name
+# #             print '#### p_units       = ' + p_units
+# #             print '#### u_units       = ' + u_units
+#             #---------------------------------------------- 
+#             values = Units.conform( values, Units(p_units), Units(u_units) )
 
         #---------------------------------------------------
         # Embed a reference to long_var_name from the
@@ -938,10 +938,10 @@ class framework():
 #         dtype = str( values.dtype )
 #         rank  = np.ndim( values )
 # 
-# 	    #------------------------------------------
+#         #------------------------------------------
 #         # Use dtype and rank to call appropriate,
 #         # static-type BMI functions.
-# 	    #------------------------------------------
+#         #------------------------------------------
 #         if (dtype == 'float64'):
 #             if (rank == 0):
 #                 bmi.set_0d_double( long_var_name, values )
@@ -951,7 +951,7 @@ class framework():
 #                 bmi.set_2d_double( long_var_name, values )
 #             elif (rank == 3):
 #                 bmi.set_3d_double( long_var_name, values )
-# 	    #------------------------------------------------------
+#         #------------------------------------------------------
 #         elif (dtype == 'int32'):
 #             if (rank == 0):
 #                 bmi.set_0d_int( long_var_name, values )
@@ -975,32 +975,32 @@ class framework():
     def get_values_at_indices( self, long_var_name, indices,
                                comp_name ):
 
-		#-------------------------------------------------------------
-		# Notes:  For the specified variable, get the values at the
-		#         specified indices and return them.  If the wrapped
-		#         model is raster, then each raster cell has a long
-		#         integer, calendar-style index and these are used
-		#         for indices.  If the wrapped model is ugrid, then
-		#         each cell in the grid has a unique, long-integer
-		#         ID and these are used for indices.
-		#-------------------------------------------------------------
+        #-------------------------------------------------------------
+        # Notes:  For the specified variable, get the values at the
+        #         specified indices and return them.  If the wrapped
+        #         model is raster, then each raster cell has a long
+        #         integer, calendar-style index and these are used
+        #         for indices.  If the wrapped model is ugrid, then
+        #         each cell in the grid has a unique, long-integer
+        #         ID and these are used for indices.
+        #-------------------------------------------------------------
 
-		#----------------------------------------------
-		# Get data type and rank for long_var_name.
-		# Assume that NumPy dtype string is returned.
-		#----------------------------------------------
-		bmi   = self.comp_set[ comp_name ]
-		return bmi.get_values_at_indices( long_var_name, indices )
-	
-# 		dtype = bmi.get_var_type( long_var_name )
-# 		rank  = bmi.get_var_rank( long_var_name )
+        #----------------------------------------------
+        # Get data type and rank for long_var_name.
+        # Assume that NumPy dtype string is returned.
+        #----------------------------------------------
+        bmi   = self.comp_set[ comp_name ]
+        return bmi.get_values_at_indices( long_var_name, indices )
+    
+#         dtype = bmi.get_var_type( long_var_name )
+#         rank  = bmi.get_var_rank( long_var_name )
 # 
-# 		if (dtype == 'float64'):
-# 			if (rank == 2):
-# 				return bmi.get_2d_double_at_indices( long_var_name, indices )
-# 		elif (dtype == 'int32'):
-# 			if (rank == 2):
-# 				return bmi.get_2d_int_at_indices( long_var_name, indices )
+#         if (dtype == 'float64'):
+#             if (rank == 2):
+#                 return bmi.get_2d_double_at_indices( long_var_name, indices )
+#         elif (dtype == 'int32'):
+#             if (rank == 2):
+#                 return bmi.get_2d_int_at_indices( long_var_name, indices )
             
     #   get_values_at_indices()
     #-------------------------------------------------------------------
@@ -1906,18 +1906,18 @@ class framework():
             # p_units = p_bmi.get_var_units( long_var_name )
             # values  = self.unit_converter.convert( values, p_units, u_units )
 
-			#---------------------------------------------------
-			# Convert units, if necessary, with cfunits.Units
-			#---------------------------------------------------
+            #---------------------------------------------------
+            # Convert units, if necessary, with cfunits.Units
+            #---------------------------------------------------
             # Storing scale factors and offsets may be faster.
-			#---------------------------------------------------
+            #---------------------------------------------------
 #             p_units = p_bmi.get_var_units( long_var_name )
 #             u_units = u_bmi.get_var_units( long_var_name )
 #             if (u_units != p_units):
-# 			    #---------------------------------------------
+#                 #---------------------------------------------
 #                 # Note: conform fails if units are the same.
-# 			    #---------------------------------------------
-# 				values = Units.conform( values, Units(p_units), Units(u_units) )
+#                 #---------------------------------------------
+#                 values = Units.conform( values, Units(p_units), Units(u_units) )
 
             #-------------------------------------------
             # Call Regridder to regrid values from the

--- a/topoflow/framework/emeli.py
+++ b/topoflow/framework/emeli.py
@@ -193,13 +193,13 @@ examples_dir  = examples_dir  + os.sep
 SILENT = False
 if not(SILENT):
 	# print ' '
-	print 'Paths for this package:'
-	print 'framework_dir =', framework_dir
-	print 'parent_dir    =', parent_dir
-	print 'examples_dir  =', examples_dir
-	print '__file__      =', __file__
-	print '__name__      =', __name__
-	print ' '
+	print('Paths for this package:')
+	print('framework_dir =', framework_dir)
+	print('parent_dir    =', parent_dir)
+	print('examples_dir  =', examples_dir)
+	print('__file__      =', __file__)
+	print('__name__      =', __name__)
+	print(' ')
 
 #--------------------------------------
 # Save the full paths in a dictionary
@@ -351,9 +351,9 @@ class framework():
         ########
     
         if not(SILENT):
-            print 'Reading info from comp_repo_file:'
-            print '    ' + comp_repo_file
-            print ' '
+            print('Reading info from comp_repo_file:')
+            print('    ' + comp_repo_file)
+            print(' ')
         
         #-------------------------------------------
         # Read all component info from an XML file
@@ -369,11 +369,11 @@ class framework():
         C_elements = dom.firstChild.getElementsByTagName("component") 
         n_comps    = len(C_elements)
         if (n_comps == 0):
-            print '########################################'
-            print ' ERROR: Component repository XML file'
-            print '        has no "component" tags.'
-            print '########################################'
-            print ' '
+            print('########################################')
+            print(' ERROR: Component repository XML file')
+            print('        has no "component" tags.')
+            print('########################################')
+            print(' ')
             return
             
         #------------------------------------------------------
@@ -484,8 +484,8 @@ class framework():
         #-----------------------------------------------------
 
         if not(SILENT):
-            print 'Reading info from provider_file:'
-            print '    ' + self.provider_file
+            print('Reading info from provider_file:')
+            print('    ' + self.provider_file)
 
         self.provider_list = []
         self.comp_set_list = []
@@ -517,12 +517,12 @@ class framework():
         # Is comp_name in repo_list ?
         #------------------------------
         if (comp_name not in self.repo_list):
-            print '#########################################'
-            print ' ERROR: There is no component named:'
-            print '    ' + comp_name
-            print ' in the component repository.'
-            print '#########################################'
-            print ' '
+            print('#########################################')
+            print(' ERROR: There is no component named:')
+            print('    ' + comp_name)
+            print(' in the component repository.')
+            print('#########################################')
+            print(' ')
             return False
         else:
             return True
@@ -705,7 +705,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print 'Instantiated component:', comp_name
+            print('Instantiated component:', comp_name)
             ## print '        of comp_type:', comp_type
 
     #   instantiate()
@@ -743,7 +743,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print 'Removed component:', comp_name
+            print('Removed component:', comp_name)
             
     #   remove()
     #-------------------------------------------------------------------
@@ -751,9 +751,9 @@ class framework():
                  long_var_name, REPORT=False ):
 
         if (REPORT):
-            print 'Connecting user: ' + user_name
-            print '    to provider: ' + provider_name
-            print '    for the variable: ' + long_var_name
+            print('Connecting user: ' + user_name)
+            print('    to provider: ' + provider_name)
+            print('    for the variable: ' + long_var_name)
 
         #---------------------------------------------
         # Get a reference to long_var_name from the
@@ -1076,11 +1076,11 @@ class framework():
         #---------------------------------------------
         status = bmi.get_status()
         if (status == 'failed'):
-            print '================================================'
-            print 'ERROR: Model run aborted.'
-            print '  Update failed on component: ' + comp_name + '.'
-            print '================================================'
-            print ' '
+            print('================================================')
+            print('ERROR: Model run aborted.')
+            print('  Update failed on component: ' + comp_name + '.')
+            print('================================================')
+            print(' ')
             self.DONE = True
     
     #   update()
@@ -1145,7 +1145,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1163,7 +1163,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1180,7 +1180,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1203,7 +1203,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1244,10 +1244,10 @@ class framework():
         DEBUG = True
         ## DEBUG = False
         if (cfg_prefix == None):
-            print 'ERROR: The "cfg_prefix" argument is required.'
+            print('ERROR: The "cfg_prefix" argument is required.')
             return
         if (cfg_directory == None):
-            print 'ERROR: The "cfg_directory" argument is required.'
+            print('ERROR: The "cfg_directory" argument is required.')
             return
         
         #--------------------------------------------------
@@ -1329,8 +1329,8 @@ class framework():
         #---------------------------------------
         driver = self.comp_set[ driver_comp_name ]
         driver.mode = 'driver'
-        print 'Driver component name =', driver_comp_name
-        print ' '
+        print('Driver component name =', driver_comp_name)
+        print(' ')
         
         #-----------------------------------
         # Initialize all time-related vars
@@ -1541,14 +1541,14 @@ class framework():
         dt_array = np.zeros( n_comps )
         dt_units = np.zeros( n_comps, dtype='|S30')   ###
         k = 0
-        print 'Original component time step sizes ='
+        print('Original component time step sizes =')
         for comp_name in self.provider_list:    
             bmi      = self.comp_set[ comp_name ]
             dt       = bmi.get_time_step()
             units    = bmi.get_time_units()
             unit_str = '[' + units + ']'
             ## print 'units =', units
-            print '    ' + comp_name + ' = ', dt, unit_str 
+            print('    ' + comp_name + ' = ', dt, unit_str) 
             dt_array[ k ] = dt
             dt_units[ k ] = units
             k += 1 
@@ -1556,8 +1556,8 @@ class framework():
         #-----------------------------------------
         # Convert all time step units to seconds
         #-----------------------------------------
-        print 'Converting all time step units to seconds...'
-        for k in xrange( n_comps ):
+        print('Converting all time step units to seconds...')
+        for k in range( n_comps ):
             dt    = dt_array[ k ]
             units = dt_units[ k ]
             dt = self.convert_time_units( dt, units )
@@ -1573,8 +1573,8 @@ class framework():
         dt_min = dt_array.min()
         self.dt = dt_min        # (framework timestep)
         dt_min_name = self.provider_list[ dt_array.argmin() ]
-        print 'Component with smallest time step is:', dt_min_name
-        print ' '
+        print('Component with smallest time step is:', dt_min_name)
+        print(' ')
 
         #----------------------------------------------
         # This is not used with new method. (4/13/13)
@@ -1673,14 +1673,14 @@ class framework():
         self.all_input_var_names.sort()
         self.all_output_var_names.sort()
         if (REPORT):
-            print 'Input variables required by this comp_set:'
+            print('Input variables required by this comp_set:')
             for name in self.all_input_var_names:
-                print '    ' + name
-            print ' '
-            print 'Output variables provided by this comp_set:'
+                print('    ' + name)
+            print(' ')
+            print('Output variables provided by this comp_set:')
             for name in self.all_output_var_names:
-                print '    ' + name
-            print ' '
+                print('    ' + name)
+            print(' ')
 
         #--------------------------------------------------- 
         # Make list of output_vars actually used by others
@@ -1715,17 +1715,17 @@ class framework():
                 provider_list = self.var_providers[ long_var_name ]
                 n_providers   = len( provider_list )
                 if (n_providers > 1):
-                    print '========================================'
-                    print ' WARNING: Found multiple providers in'
-                    print '          comp_set for long_var_name:'
-                    print '            ' + long_var_name
-                    print ' Providers are:', provider_list
+                    print('========================================')
+                    print(' WARNING: Found multiple providers in')
+                    print('          comp_set for long_var_name:')
+                    print('            ' + long_var_name)
+                    print(' Providers are:', provider_list)
                     OK = False
             else:
-                print '========================================'
-                print ' WARNING: Found no providers in this'
-                print '          comp_set for long_var_name:'
-                print '            ' + long_var_name
+                print('========================================')
+                print(' WARNING: Found no providers in this')
+                print('          comp_set for long_var_name:')
+                print('            ' + long_var_name)
                 ### print,'          requested by: ' + ??????
                 OK = False
 
@@ -1802,7 +1802,7 @@ class framework():
             #-------------------------------------------
             cfg_file = self.get_cfg_filename( bmi )
             self.initialize( provider_name, cfg_file )
-            print 'Initialized component: ' + provider_name + '.'
+            print('Initialized component: ' + provider_name + '.')
             ## print 'Initialized component of type: ' + provider_name + '.'
             ## print 'Initialized: ' + comp_name + '.'
 
@@ -1937,9 +1937,9 @@ class framework():
             #------------------
             REPORT = False
             if (REPORT):
-                print 'user: ' + user_name
-                print '    just obtained var:  ' + long_var_name
-                print '    from provider: ' + provider_name
+                print('user: ' + user_name)
+                print('    just obtained var:  ' + long_var_name)
+                print('    from provider: ' + provider_name)
            
     #   get_required_vars()
     #-------------------------------------------------------------------

--- a/topoflow/framework/emeli.py
+++ b/topoflow/framework/emeli.py
@@ -666,8 +666,9 @@ class framework():
         #--------------------------------------------
         ## print '### full_module_name = ', full_module_name
         cmd = 'from topoflow.components import ' + module_name
-        exec( cmd )
-        exec( 'comp = ' + module_name + '.' + class_name + '()' )
+        exec( cmd, globals(), globals() )
+        exec( 'comp = ' + module_name + '.' + class_name + '()',
+             globals(), globals())
 
         #--------------------------------------------
         # Import the module (no .py extension) and

--- a/topoflow/framework/emeli.py
+++ b/topoflow/framework/emeli.py
@@ -194,11 +194,11 @@ SILENT = False
 if not(SILENT):
 	# print ' '
 	print('Paths for this package:')
-	print('framework_dir =', framework_dir)
-	print('parent_dir    =', parent_dir)
-	print('examples_dir  =', examples_dir)
-	print('__file__      =', __file__)
-	print('__name__      =', __name__)
+	print('framework_dir = %s' % framework_dir)
+	print('parent_dir    = %s' % parent_dir)
+	print('examples_dir  = %s' % examples_dir)
+	print('__file__      = %s' % __file__)
+	print('__name__      = %s' % __name__)
 	print(' ')
 
 #--------------------------------------
@@ -352,7 +352,7 @@ class framework():
     
         if not(SILENT):
             print('Reading info from comp_repo_file:')
-            print('    ' + comp_repo_file)
+            print('     ' + comp_repo_file)
             print(' ')
         
         #-------------------------------------------
@@ -485,7 +485,7 @@ class framework():
 
         if not(SILENT):
             print('Reading info from provider_file:')
-            print('    ' + self.provider_file)
+            print('     ' + self.provider_file)
 
         self.provider_list = []
         self.comp_set_list = []
@@ -705,7 +705,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print('Instantiated component:', comp_name)
+            print('Instantiated component: %s' % comp_name)
             ## print '        of comp_type:', comp_type
 
     #   instantiate()
@@ -743,7 +743,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print('Removed component:', comp_name)
+            print('Removed component: %s' % comp_name)
             
     #   remove()
     #-------------------------------------------------------------------
@@ -1329,7 +1329,7 @@ class framework():
         #---------------------------------------
         driver = self.comp_set[ driver_comp_name ]
         driver.mode = 'driver'
-        print('Driver component name =', driver_comp_name)
+        print('Driver component name = %s' % driver_comp_name)
         print(' ')
         
         #-----------------------------------
@@ -1548,7 +1548,7 @@ class framework():
             units    = bmi.get_time_units()
             unit_str = '[' + units + ']'
             ## print 'units =', units
-            print('    ' + comp_name + ' = ', dt, unit_str) 
+            print('    %s = %s %s' % (comp_name, dt, unit_str))
             dt_array[ k ] = dt
             dt_units[ k ] = units
             k += 1 
@@ -1573,7 +1573,7 @@ class framework():
         dt_min = dt_array.min()
         self.dt = dt_min        # (framework timestep)
         dt_min_name = self.provider_list[ dt_array.argmin() ]
-        print('Component with smallest time step is:', dt_min_name)
+        print('Component with smallest time step is: %s' % dt_min_name)
         print(' ')
 
         #----------------------------------------------

--- a/topoflow/framework/emeli_with_cfunits.py
+++ b/topoflow/framework/emeli_with_cfunits.py
@@ -187,11 +187,11 @@ SILENT = False
 if not(SILENT):
 	# print ' '
 	print('Paths for this package:')
-	print('framework_dir =', framework_dir)
-	print('parent_dir    =', parent_dir)
-	print('examples_dir  =', examples_dir)
-	print('__file__      =', __file__)
-	print('__name__      =', __name__)
+	print('framework_dir = %s' % framework_dir)
+	print('parent_dir    = %s' % parent_dir)
+	print('examples_dir  = %s' % examples_dir)
+	print('__file__      = %s' % __file__)
+	print('__name__      = %s' % __name__)
 	print(' ')
 
 #--------------------------------------
@@ -698,7 +698,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print('Instantiated component:', comp_name)
+            print('Instantiated component: %s' % comp_name)
             ## print '        of comp_type:', comp_type
 
     #   instantiate()
@@ -736,7 +736,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print('Removed component:', comp_name)
+            print('Removed component: %s' % comp_name)
             
     #   remove()
     #-------------------------------------------------------------------
@@ -1316,7 +1316,7 @@ class framework():
         #---------------------------------------
         driver = self.comp_set[ driver_comp_name ]
         driver.mode = 'driver'
-        print('Driver component name =', driver_comp_name)
+        print('Driver component name = %s' % driver_comp_name)
         print(' ')
         
         #-----------------------------------
@@ -1535,7 +1535,7 @@ class framework():
             units    = bmi.get_time_units()
             unit_str = '[' + units + ']'
             ## print 'units =', units
-            print('    ' + comp_name + ' = ', dt, unit_str) 
+            print('    %s = %s %s' % (comp_name, dt, unit_str))
             dt_array[ k ] = dt
             dt_units[ k ] = units
             k += 1 
@@ -1560,7 +1560,7 @@ class framework():
         dt_min = dt_array.min()
         self.dt = dt_min        # (framework timestep)
         dt_min_name = self.provider_list[ dt_array.argmin() ]
-        print('Component with smallest time step is:', dt_min_name)
+        print('Component with smallest time step is: %s' % dt_min_name)
         print(' ')
 
         #----------------------------------------------

--- a/topoflow/framework/emeli_with_cfunits.py
+++ b/topoflow/framework/emeli_with_cfunits.py
@@ -659,8 +659,9 @@ class framework():
         #--------------------------------------------
         ## print '### full_module_name = ', full_module_name
         cmd = 'from topoflow.components import ' + module_name
-        exec( cmd )
-        exec( 'comp = ' + module_name + '.' + class_name + '()' )
+        exec( cmd, globals(), globals() )
+        exec( 'comp = ' + module_name + '.' + class_name + '()',
+             globals(), globals())
 
         #--------------------------------------------
         # Import the module (no .py extension) and

--- a/topoflow/framework/emeli_with_cfunits.py
+++ b/topoflow/framework/emeli_with_cfunits.py
@@ -185,14 +185,14 @@ examples_dir  = examples_dir  + os.sep
 
 SILENT = False
 if not(SILENT):
-	# print ' '
-	print('Paths for this package:')
-	print('framework_dir = %s' % framework_dir)
-	print('parent_dir    = %s' % parent_dir)
-	print('examples_dir  = %s' % examples_dir)
-	print('__file__      = %s' % __file__)
-	print('__name__      = %s' % __name__)
-	print(' ')
+    # print ' '
+    print('Paths for this package:')
+    print('framework_dir = %s' % framework_dir)
+    print('parent_dir    = %s' % parent_dir)
+    print('examples_dir  = %s' % examples_dir)
+    print('__file__      = %s' % __file__)
+    print('__name__      = %s' % __name__)
+    print(' ')
 
 #--------------------------------------
 # Save the full paths in a dictionary
@@ -260,31 +260,31 @@ class framework():
     secs_per_year  = 365 * secs_per_day
     secs_per_month = secs_per_year / 12    #########
 
-# 	##################################################################
-# 	# NOTE:  "get_package_paths" will not work as intended on Python
-# 	# versions less than 3.4 if os.chddir() is called between two
-# 	# calls to get_package_paths().  This is a known Python issue
-# 	# that has been discussed frequently online.  (9/17/14)
-# 	##################################################################
+#     ##################################################################
+#     # NOTE:  "get_package_paths" will not work as intended on Python
+#     # versions less than 3.4 if os.chddir() is called between two
+#     # calls to get_package_paths().  This is a known Python issue
+#     # that has been discussed frequently online.  (9/17/14)
+#     ##################################################################
 # 
-# 	#------------------------------------------------------
-# 	# Get path to the current file (emeli.py).  (7/29/13)
-# 	# At top need: "#! /usr/bin/env python" ??
-# 	# See: https://docs.python.org/2/library/os.path.html
-# 	#------------------------------------------------------
+#     #------------------------------------------------------
+#     # Get path to the current file (emeli.py).  (7/29/13)
+#     # At top need: "#! /usr/bin/env python" ??
+#     # See: https://docs.python.org/2/library/os.path.html
+#     #------------------------------------------------------
 #     framework_dir = os.path.dirname( __file__ )
 #     parent_dir    = os.path.join( framework_dir, '..' )
 #     # parent_dir    = os.path.join( framework_dir, os.path.pardir )
 #     examples_dir  = os.path.join( parent_dir, 'examples' )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 #     framework_dir = os.path.abspath( framework_dir )
 #     parent_dir    = os.path.abspath( parent_dir )
 #     examples_dir  = os.path.abspath( examples_dir )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 # #     framework_dir = os.path.realpath( framework_dir )
 # #     parent_dir    = os.path.realpath( parent_dir )
 # #     examples_dir  = os.path.realpath( examples_dir )
-# 	#-------------------------------------------------------
+#     #-------------------------------------------------------
 #     framework_dir = framework_dir + os.sep
 #     parent_dir    = parent_dir    + os.sep
 #     examples_dir  = examples_dir  + os.sep
@@ -299,15 +299,15 @@ class framework():
 #         print '__file__      =', __file__
 #         print '__name__      =', __name__
 #         print ' '
-# 	
-# 	#--------------------------------------
-# 	# Save the full paths in a dictionary
-# 	#--------------------------------------
+#     
+#     #--------------------------------------
+#     # Save the full paths in a dictionary
+#     #--------------------------------------
 #     paths = dict()
 #     paths['framework']        = framework_dir
 #     paths['examples']         = examples_dir
 #     paths['framework_parent'] = parent_dir
-		
+        
     #-------------------------------------------------------------------
     def read_repository( self, SILENT=True ):
 
@@ -925,10 +925,10 @@ class framework():
 #         dtype = str( values.dtype )
 #         rank  = np.ndim( values )
 # 
-# 	    #------------------------------------------
+#         #------------------------------------------
 #         # Use dtype and rank to call appropriate,
 #         # static-type BMI functions.
-# 	    #------------------------------------------
+#         #------------------------------------------
 #         if (dtype == 'float64'):
 #             if (rank == 0):
 #                 bmi.set_0d_double( long_var_name, values )
@@ -938,7 +938,7 @@ class framework():
 #                 bmi.set_2d_double( long_var_name, values )
 #             elif (rank == 3):
 #                 bmi.set_3d_double( long_var_name, values )
-# 	    #------------------------------------------------------
+#         #------------------------------------------------------
 #         elif (dtype == 'int32'):
 #             if (rank == 0):
 #                 bmi.set_0d_int( long_var_name, values )
@@ -962,32 +962,32 @@ class framework():
     def get_values_at_indices( self, long_var_name, indices,
                                comp_name ):
 
-		#-------------------------------------------------------------
-		# Notes:  For the specified variable, get the values at the
-		#         specified indices and return them.  If the wrapped
-		#         model is raster, then each raster cell has a long
-		#         integer, calendar-style index and these are used
-		#         for indices.  If the wrapped model is ugrid, then
-		#         each cell in the grid has a unique, long-integer
-		#         ID and these are used for indices.
-		#-------------------------------------------------------------
+        #-------------------------------------------------------------
+        # Notes:  For the specified variable, get the values at the
+        #         specified indices and return them.  If the wrapped
+        #         model is raster, then each raster cell has a long
+        #         integer, calendar-style index and these are used
+        #         for indices.  If the wrapped model is ugrid, then
+        #         each cell in the grid has a unique, long-integer
+        #         ID and these are used for indices.
+        #-------------------------------------------------------------
 
-		#----------------------------------------------
-		# Get data type and rank for long_var_name.
-		# Assume that NumPy dtype string is returned.
-		#----------------------------------------------
-		bmi   = self.comp_set[ comp_name ]
-		return bmi.get_values_at_indices( long_var_name, indices )
-	
-# 		dtype = bmi.get_var_type( long_var_name )
-# 		rank  = bmi.get_var_rank( long_var_name )
+        #----------------------------------------------
+        # Get data type and rank for long_var_name.
+        # Assume that NumPy dtype string is returned.
+        #----------------------------------------------
+        bmi   = self.comp_set[ comp_name ]
+        return bmi.get_values_at_indices( long_var_name, indices )
+    
+#         dtype = bmi.get_var_type( long_var_name )
+#         rank  = bmi.get_var_rank( long_var_name )
 # 
-# 		if (dtype == 'float64'):
-# 			if (rank == 2):
-# 				return bmi.get_2d_double_at_indices( long_var_name, indices )
-# 		elif (dtype == 'int32'):
-# 			if (rank == 2):
-# 				return bmi.get_2d_int_at_indices( long_var_name, indices )
+#         if (dtype == 'float64'):
+#             if (rank == 2):
+#                 return bmi.get_2d_double_at_indices( long_var_name, indices )
+#         elif (dtype == 'int32'):
+#             if (rank == 2):
+#                 return bmi.get_2d_int_at_indices( long_var_name, indices )
             
     #   get_values_at_indices()
     #-------------------------------------------------------------------
@@ -1892,18 +1892,18 @@ class framework():
             # p_units = p_bmi.get_var_units( long_var_name )
             # values  = self.unit_converter.convert( values, p_units, u_units )
 
-			#---------------------------------------------------
-			# Convert units, if necessary, with cfunits.Units
-			#---------------------------------------------------
+            #---------------------------------------------------
+            # Convert units, if necessary, with cfunits.Units
+            #---------------------------------------------------
             # Storing scale factors and offsets may be faster.
-			#---------------------------------------------------
+            #---------------------------------------------------
             p_units = p_bmi.get_var_units( long_var_name )
             u_units = u_bmi.get_var_units( long_var_name )
             if (u_units != p_units):
-			    #---------------------------------------------
+                #---------------------------------------------
                 # Note: conform fails if units are the same.
-			    #---------------------------------------------
-				values = Units.conform( values, Units(p_units), Units(u_units) )
+                #---------------------------------------------
+                values = Units.conform( values, Units(p_units), Units(u_units) )
 
             #-------------------------------------------
             # Call Regridder to regrid values from the

--- a/topoflow/framework/emeli_with_cfunits.py
+++ b/topoflow/framework/emeli_with_cfunits.py
@@ -186,13 +186,13 @@ examples_dir  = examples_dir  + os.sep
 SILENT = False
 if not(SILENT):
 	# print ' '
-	print 'Paths for this package:'
-	print 'framework_dir =', framework_dir
-	print 'parent_dir    =', parent_dir
-	print 'examples_dir  =', examples_dir
-	print '__file__      =', __file__
-	print '__name__      =', __name__
-	print ' '
+	print('Paths for this package:')
+	print('framework_dir =', framework_dir)
+	print('parent_dir    =', parent_dir)
+	print('examples_dir  =', examples_dir)
+	print('__file__      =', __file__)
+	print('__name__      =', __name__)
+	print(' ')
 
 #--------------------------------------
 # Save the full paths in a dictionary
@@ -344,9 +344,9 @@ class framework():
         ########
     
         if not(SILENT):
-            print 'Reading info from comp_repo_file:'
-            print '    ' + comp_repo_file
-            print ' '
+            print('Reading info from comp_repo_file:')
+            print('    ' + comp_repo_file)
+            print(' ')
         
         #-------------------------------------------
         # Read all component info from an XML file
@@ -362,11 +362,11 @@ class framework():
         C_elements = dom.firstChild.getElementsByTagName("component") 
         n_comps    = len(C_elements)
         if (n_comps == 0):
-            print '########################################'
-            print ' ERROR: Component repository XML file'
-            print '        has no "component" tags.'
-            print '########################################'
-            print ' '
+            print('########################################')
+            print(' ERROR: Component repository XML file')
+            print('        has no "component" tags.')
+            print('########################################')
+            print(' ')
             return
             
         #------------------------------------------------------
@@ -477,8 +477,8 @@ class framework():
         #-----------------------------------------------------
 
         if not(SILENT):
-            print 'Reading info from provider_file:'
-            print '    ' + self.provider_file
+            print('Reading info from provider_file:')
+            print('    ' + self.provider_file)
 
         self.provider_list = []
         self.comp_set_list = []
@@ -510,12 +510,12 @@ class framework():
         # Is comp_name in repo_list ?
         #------------------------------
         if (comp_name not in self.repo_list):
-            print '#########################################'
-            print ' ERROR: There is no component named:'
-            print '    ' + comp_name
-            print ' in the component repository.'
-            print '#########################################'
-            print ' '
+            print('#########################################')
+            print(' ERROR: There is no component named:')
+            print('    ' + comp_name)
+            print(' in the component repository.')
+            print('#########################################')
+            print(' ')
             return False
         else:
             return True
@@ -698,7 +698,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print 'Instantiated component:', comp_name
+            print('Instantiated component:', comp_name)
             ## print '        of comp_type:', comp_type
 
     #   instantiate()
@@ -736,7 +736,7 @@ class framework():
         # Final message
         #----------------
         if not(SILENT):
-            print 'Removed component:', comp_name
+            print('Removed component:', comp_name)
             
     #   remove()
     #-------------------------------------------------------------------
@@ -744,9 +744,9 @@ class framework():
                  long_var_name, REPORT=False ):
 
         if (REPORT):
-            print 'Connecting user: ' + user_name
-            print '    to provider: ' + provider_name
-            print '    for the variable: ' + long_var_name
+            print('Connecting user: ' + user_name)
+            print('    to provider: ' + provider_name)
+            print('    for the variable: ' + long_var_name)
 
         #---------------------------------------------
         # Get a reference to long_var_name from the
@@ -1063,11 +1063,11 @@ class framework():
         #---------------------------------------------
         status = bmi.get_status()
         if (status == 'failed'):
-            print '================================================'
-            print 'ERROR: Model run aborted.'
-            print '  Update failed on component: ' + comp_name + '.'
-            print '================================================'
-            print ' '
+            print('================================================')
+            print('ERROR: Model run aborted.')
+            print('  Update failed on component: ' + comp_name + '.')
+            print('================================================')
+            print(' ')
             self.DONE = True
     
     #   update()
@@ -1132,7 +1132,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1150,7 +1150,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1167,7 +1167,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1190,7 +1190,7 @@ class framework():
         #       is an unordered dictionary.
         #--------------------------------------------------
         if not(hasattr(self, 'provider_list')):
-            print 'Providers not yet read from provider_file.'
+            print('Providers not yet read from provider_file.')
             return
         
         for comp_name in self.provider_list:
@@ -1231,10 +1231,10 @@ class framework():
         DEBUG = True
         ## DEBUG = False
         if (cfg_prefix == None):
-            print 'ERROR: The "cfg_prefix" argument is required.'
+            print('ERROR: The "cfg_prefix" argument is required.')
             return
         if (cfg_directory == None):
-            print 'ERROR: The "cfg_directory" argument is required.'
+            print('ERROR: The "cfg_directory" argument is required.')
             return
         
         #--------------------------------------------------
@@ -1316,8 +1316,8 @@ class framework():
         #---------------------------------------
         driver = self.comp_set[ driver_comp_name ]
         driver.mode = 'driver'
-        print 'Driver component name =', driver_comp_name
-        print ' '
+        print('Driver component name =', driver_comp_name)
+        print(' ')
         
         #-----------------------------------
         # Initialize all time-related vars
@@ -1528,14 +1528,14 @@ class framework():
         dt_array = np.zeros( n_comps )
         dt_units = np.zeros( n_comps, dtype='|S30')   ###
         k = 0
-        print 'Original component time step sizes ='
+        print('Original component time step sizes =')
         for comp_name in self.provider_list:    
             bmi      = self.comp_set[ comp_name ]
             dt       = bmi.get_time_step()
             units    = bmi.get_time_units()
             unit_str = '[' + units + ']'
             ## print 'units =', units
-            print '    ' + comp_name + ' = ', dt, unit_str 
+            print('    ' + comp_name + ' = ', dt, unit_str) 
             dt_array[ k ] = dt
             dt_units[ k ] = units
             k += 1 
@@ -1543,8 +1543,8 @@ class framework():
         #-----------------------------------------
         # Convert all time step units to seconds
         #-----------------------------------------
-        print 'Converting all time step units to seconds...'
-        for k in xrange( n_comps ):
+        print('Converting all time step units to seconds...')
+        for k in range( n_comps ):
             dt    = dt_array[ k ]
             units = dt_units[ k ]
             dt = self.convert_time_units( dt, units )
@@ -1560,8 +1560,8 @@ class framework():
         dt_min = dt_array.min()
         self.dt = dt_min        # (framework timestep)
         dt_min_name = self.provider_list[ dt_array.argmin() ]
-        print 'Component with smallest time step is:', dt_min_name
-        print ' '
+        print('Component with smallest time step is:', dt_min_name)
+        print(' ')
 
         #----------------------------------------------
         # This is not used with new method. (4/13/13)
@@ -1660,14 +1660,14 @@ class framework():
         self.all_input_var_names.sort()
         self.all_output_var_names.sort()
         if (REPORT):
-            print 'Input variables required by this comp_set:'
+            print('Input variables required by this comp_set:')
             for name in self.all_input_var_names:
-                print '    ' + name
-            print ' '
-            print 'Output variables provided by this comp_set:'
+                print('    ' + name)
+            print(' ')
+            print('Output variables provided by this comp_set:')
             for name in self.all_output_var_names:
-                print '    ' + name
-            print ' '
+                print('    ' + name)
+            print(' ')
 
         #--------------------------------------------------- 
         # Make list of output_vars actually used by others
@@ -1702,17 +1702,17 @@ class framework():
                 provider_list = self.var_providers[ long_var_name ]
                 n_providers   = len( provider_list )
                 if (n_providers > 1):
-                    print '========================================'
-                    print ' WARNING: Found multiple providers in'
-                    print '          comp_set for long_var_name:'
-                    print '            ' + long_var_name
-                    print ' Providers are:', provider_list
+                    print('========================================')
+                    print(' WARNING: Found multiple providers in')
+                    print('          comp_set for long_var_name:')
+                    print('            ' + long_var_name)
+                    print(' Providers are:', provider_list)
                     OK = False
             else:
-                print '========================================'
-                print ' WARNING: Found no providers in this'
-                print '          comp_set for long_var_name:'
-                print '            ' + long_var_name
+                print('========================================')
+                print(' WARNING: Found no providers in this')
+                print('          comp_set for long_var_name:')
+                print('            ' + long_var_name)
                 ### print,'          requested by: ' + ??????
                 OK = False
 
@@ -1789,7 +1789,7 @@ class framework():
             #-------------------------------------------
             cfg_file = self.get_cfg_filename( bmi )
             self.initialize( provider_name, cfg_file )
-            print 'Initialized component: ' + provider_name + '.'
+            print('Initialized component: ' + provider_name + '.')
             ## print 'Initialized component of type: ' + provider_name + '.'
             ## print 'Initialized: ' + comp_name + '.'
 
@@ -1923,9 +1923,9 @@ class framework():
             #------------------
             REPORT = False
             if (REPORT):
-                print 'user: ' + user_name
-                print '    just obtained var:  ' + long_var_name
-                print '    from provider: ' + provider_name
+                print('user: ' + user_name)
+                print('    just obtained var:  ' + long_var_name)
+                print('    from provider: ' + provider_name)
            
     #   get_required_vars()
     #-------------------------------------------------------------------

--- a/topoflow/framework/tests/test_framework.py
+++ b/topoflow/framework/tests/test_framework.py
@@ -252,7 +252,7 @@ def ref_test():
     #-----------------------------------------------------
     class comp2():
         def print_x(self):
-            print('After c1.update(), c2.x =', self.x)
+            print('After c1.update(), c2.x = %s' % self.x)
         #-------------------------------------------------
         def set_values(self, var_name, scalar):
             setattr( self, var_name, scalar )
@@ -319,9 +319,9 @@ def framework_test1():
 
     tf_comp_info = f.comp_info[ 'topoflow_driver' ]  
     print('Checking some info for "topoflow_driver":')
-    print('    comp_name  =', tf_comp_info.comp_name)
-    print('    model_name =', tf_comp_info.model_name)
-    print('    uses_ports =', tf_comp_info.uses_ports)
+    print('    comp_name  = %s' % tf_comp_info.comp_name)
+    print('    model_name = %s' % tf_comp_info.model_name)
+    print('    uses_ports = %s' % tf_comp_info.uses_ports)
     print(' ')
 
     #--------------------------------------------
@@ -342,7 +342,7 @@ def framework_test1():
     for comp_name in comp_list:
         f.instantiate( comp_name, SILENT=False )
     print(' ')
-    print('ALL_PYTHON =', f.ALL_PYTHON)
+    print('ALL_PYTHON = %s' % f.ALL_PYTHON)
     print(' ')
 
     #------------------------------------------
@@ -435,10 +435,10 @@ def framework_test1():
     snow_comp = f.comp_set['snow']
     met_comp  = f.comp_set['meteorology']
     print(' ')
-    print('From meteorology, snow got: density of water =', \
+    print('From meteorology, snow got: density of water = %s' % \
           snow_comp.rho_H2O)
           ### snow_comp.met_vars.rho_H2O
-    print('From snow, meteorology got: density of snow  =', \
+    print('From snow, meteorology got: density of snow  = %s' % \
           met_comp.rho_snow)
           ### met_comp.snow_vars.rho_snow
     

--- a/topoflow/framework/tests/test_framework.py
+++ b/topoflow/framework/tests/test_framework.py
@@ -252,7 +252,7 @@ def ref_test():
     #-----------------------------------------------------
     class comp2():
         def print_x(self):
-            print 'After c1.update(), c2.x =', self.x
+            print('After c1.update(), c2.x =', self.x)
         #-------------------------------------------------
         def set_values(self, var_name, scalar):
             setattr( self, var_name, scalar )
@@ -291,7 +291,7 @@ def ref_test():
 #     cmd = "setattr(self, 'x[True]', random.random() )"
 #     print '0d array update test.  Command: ' + cmd
 
-    for k in xrange(3):
+    for k in range(3):
         c1.update()
         c2.print_x()
     
@@ -312,17 +312,17 @@ def framework_test1():
     f.cfg_prefix = 'June_20_67'
     
     f.read_repository( SILENT=False )  
-    print 'Components in repository:'
+    print('Components in repository:')
     for comp_name in f.repo_list:
-        print '   ' + comp_name
-    print ' '
+        print('   ' + comp_name)
+    print(' ')
 
     tf_comp_info = f.comp_info[ 'topoflow_driver' ]  
-    print 'Checking some info for "topoflow_driver":'
-    print '    comp_name  =', tf_comp_info.comp_name
-    print '    model_name =', tf_comp_info.model_name
-    print '    uses_ports =', tf_comp_info.uses_ports
-    print ' '
+    print('Checking some info for "topoflow_driver":')
+    print('    comp_name  =', tf_comp_info.comp_name)
+    print('    model_name =', tf_comp_info.model_name)
+    print('    uses_ports =', tf_comp_info.uses_ports)
+    print(' ')
 
     #--------------------------------------------
     # Instantiate a complete set of components.
@@ -341,9 +341,9 @@ def framework_test1():
                  'topoflow_driver' ]
     for comp_name in comp_list:
         f.instantiate( comp_name, SILENT=False )
-    print ' '
-    print 'ALL_PYTHON =', f.ALL_PYTHON
-    print ' '
+    print(' ')
+    print('ALL_PYTHON =', f.ALL_PYTHON)
+    print(' ')
 
     #------------------------------------------
     # Check if all uses ports have a provider
@@ -394,16 +394,16 @@ def framework_test1():
     ## cfg_file = None
     ## f.initialize( 'meteorology', cfg_file )
     f.initialize( 'meteorology' )
-    print 'Initialized component of type: meteorology.'
+    print('Initialized component of type: meteorology.')
     ## f.initialize( 'snow', cfg_file)
     f.initialize( 'snow' )
-    print 'Initialized component of type: snow.'   
-    print ' '
+    print('Initialized component of type: snow.')   
+    print(' ')
 
     #--------------------------------------------
     # Copy references from Meteorology to Snow.
     #--------------------------------------------
-    print 'Copying references from Meteorology to Snow component...'
+    print('Copying references from Meteorology to Snow component...')
     provider_name = 'meteorology'
     user_name     = 'snow'
     var_name_list = ['atmosphere_bottom_air__temperature',
@@ -418,7 +418,7 @@ def framework_test1():
     #--------------------------------------------
     # Copy references from Snow to Meteorology.
     #--------------------------------------------
-    print 'Copying references from Snow to Meteorology component...'
+    print('Copying references from Snow to Meteorology component...')
     provider_name = 'snow'
     user_name     = 'meteorology'
     var_name_list = [ 'snowpack__depth',
@@ -434,19 +434,19 @@ def framework_test1():
     #---------------------------------------
     snow_comp = f.comp_set['snow']
     met_comp  = f.comp_set['meteorology']
-    print ' '
-    print 'From meteorology, snow got: density of water =', \
-          snow_comp.rho_H2O
+    print(' ')
+    print('From meteorology, snow got: density of water =', \
+          snow_comp.rho_H2O)
           ### snow_comp.met_vars.rho_H2O
-    print 'From snow, meteorology got: density of snow  =', \
-          met_comp.rho_snow
+    print('From snow, meteorology got: density of snow  =', \
+          met_comp.rho_snow)
           ### met_comp.snow_vars.rho_snow
     
     #----------------
     # Final message
     #----------------
-    print 'Finished with framework_test1.'
-    print ' '
+    print('Finished with framework_test1.')
+    print(' ')
     
 #   framework_test1()
 #-----------------------------------------------------------------------
@@ -465,10 +465,10 @@ def framework_test2():
     f.cfg_directory = examples_dir + 'Treynor_Iowa/'
     f.cfg_prefix = 'June_20_67'  # (needed by initialize())
         
-    print 'Components in repository:'
+    print('Components in repository:')
     for comp_name in f.repo_list:
-        print '   ' + comp_name
-    print ' '
+        print('   ' + comp_name)
+    print(' ')
  
     #-----------------------------------------------------
     # Set self.comp_set_list and self.provider_list
@@ -503,7 +503,7 @@ def framework_test2():
     # Call update() for each provider, in order.
     # Don't worry about reconciling time steps yet.
     #------------------------------------------------
-    print ' '
+    print(' ')
     # f.update_all()  # (not ordered)
 
 ##    for k in xrange(10):
@@ -523,8 +523,8 @@ def framework_test2():
     #----------------
     # Final message
     #----------------
-    print 'Finished with framework_test2.'
-    print ' '
+    print('Finished with framework_test2.')
+    print(' ')
 
 #   framework_test2()
 #-----------------------------------------------------------------------

--- a/topoflow/framework/time_interpolation.py
+++ b/topoflow/framework/time_interpolation.py
@@ -182,8 +182,8 @@ class time_interpolator():
         self.provider_comp_list   = comp_names
         self.vars_provided        = vars_provided
         self.interpolation_method = method
-        print 'Time interpolation method =', method
-        print ' '
+        print('Time interpolation method =', method)
+        print(' ')
         
     #   __init__()
     #----------------------------------------------------------   
@@ -643,13 +643,13 @@ class time_interpolator():
             #------------------------------------
             bmi_time = bmi.get_current_time()
             if (time > bmi_time):
-                print '=================================================='
-                print ' ERROR:  In time_interpolation.get_values():'
-                print '   Model time > BMI component time'
-                print '     for component =', comp_name
-                print '   Model time, BMI_time =', time, bmi_time
-                print '=================================================='
-                print ' '
+                print('==================================================')
+                print(' ERROR:  In time_interpolation.get_values():')
+                print('   Model time > BMI component time')
+                print('     for component =', comp_name)
+                print('   Model time, BMI_time =', time, bmi_time)
+                print('==================================================')
+                print(' ')
                 
             return bmi.get_values( long_var_name )
 
@@ -666,13 +666,13 @@ class time_interpolator():
             # For testing. Is time in interval?
             #------------------------------------           
             if (time > i_vars.t2):
-                print '=================================================='
-                print ' ERROR:  In time_interpolation.get_values():'
-                print '   Model time is outside interpolation window'
-                print '     for component =', comp_name
-                print '   model_time, t2 =', time, i_vars.t2
-                print '=================================================='
-                print ' '
+                print('==================================================')
+                print(' ERROR:  In time_interpolation.get_values():')
+                print('   Model time is outside interpolation window')
+                print('     for component =', comp_name)
+                print('   model_time, t2 =', time, i_vars.t2)
+                print('==================================================')
+                print(' ')
 
             value = (i_vars.a * time) + i_vars.b
 

--- a/topoflow/framework/time_interpolation.py
+++ b/topoflow/framework/time_interpolation.py
@@ -182,7 +182,7 @@ class time_interpolator():
         self.provider_comp_list   = comp_names
         self.vars_provided        = vars_provided
         self.interpolation_method = method
-        print('Time interpolation method =', method)
+        print('Time interpolation method = %s' % method)
         print(' ')
         
     #   __init__()


### PR DESCRIPTION
This PR makes some trivial changes to files in topoflow.framework to make them Python 3 compatible (while of course remaining Python 2 compatible). 
The only changes needed were:
- put parentheses around `print`s
- replace commas in prints to use formatting instead
- change `xrange` to `range`
- add `globals()` to the `exec()` calls to make variables visible
- change all tabs to 4 spaces since indentation was inconsistent and Python 3 is sensitive to that