### PR TITLE
Dockerfile to install Topoflow in a container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM centos:7
-  
+
 LABEL maintainer="Scott D. Peckham <Scott.Peckham@colorado.edu>" contributor="Rajiv Mayani <mayani@isi.edu>"
 
-RUN yum -y update && yum -y install epel-release && yum -y install python36
+RUN yum -y update && yum -y install epel-release && yum -y install python-setuptools python-pip numpy scipy
+# RUN yum -y update && yum -y install epel-release && yum -y install python36
 
 RUN mkdir /srv/topoflow
 
 ADD . /srv/topoflow
 
-RUN cd /srv/topoflow && pip3 install .
+RUN cd /srv/topoflow && pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM centos:7
+  
+LABEL maintainer="Scott D. Peckham <Scott.Peckham@colorado.edu>" contributor="Rajiv Mayani <mayani@isi.edu>"
+
+RUN yum -y update && yum -y install epel-release && yum -y install python36
+
+RUN mkdir /srv/topoflow
+
+ADD . /srv/topoflow
+
+RUN cd /srv/topoflow && pip3 install .


### PR DESCRIPTION
Requires Python 3 compatibility changes in ez_setup.py to work.